### PR TITLE
Update new-moon.itermcolors

### DIFF
--- a/iterm2/new-moon.itermcolors
+++ b/iterm2/new-moon.itermcolors
@@ -7,13 +7,13 @@
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.77254903316497803</real>
+		<real>0.20000000298023224</real>
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.72549021244049072</real>
+		<real>0.20000000298023224</real>
 		<key>Red Component</key>
-		<real>0.70196080207824707</real>
+		<real>0.20000000298023224</real>
 	</dict>
 	<key>Ansi 1 Color</key>
 	<dict>
@@ -189,13 +189,13 @@
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.77254903316497803</real>
+		<real>0.20000000298023224</real>
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.72549021244049072</real>
+		<real>0.20000000298023224</real>
 		<key>Red Component</key>
-		<real>0.70196080207824707</real>
+		<real>0.20000000298023224</real>
 	</dict>
 	<key>Ansi 9 Color</key>
 	<dict>


### PR DESCRIPTION
Change `ANSI 0` and `ANSI 8` to the same dark grey colour used for `Selection Color`

Fixes #6 

## Before

![image](https://user-images.githubusercontent.com/1347511/53602216-fbb38680-3ba5-11e9-8ab0-cd39862e83bd.png)

## After

![image](https://user-images.githubusercontent.com/1347511/53603257-d3795700-3ba8-11e9-8f4c-d0c49e3142ef.png)
